### PR TITLE
add tagged template code highlighting

### DIFF
--- a/src/readme-container.js
+++ b/src/readme-container.js
@@ -8,8 +8,8 @@ import * as Lit from 'lit-html';
 import 'prismjs';
 
 /**
- * readme-container element displays the README file of the active project. 
- * Currently it uses an iframe populated with an HTML document, 
+ * readme-container element displays the README file of the active project.
+ * Currently it uses an iframe populated with an HTML document,
  * which is generated from the project's README.md during the build process.
  */
 export class ReadmeContainer extends LitElement{
@@ -24,6 +24,38 @@ export class ReadmeContainer extends LitElement{
    * Highlight code blocks in shadow DOM using prismjs API.
    */
   async highlightCodeBlocks(){
+    // add tagged template literal highlighting if not already defined
+    if (!Prism.languages.javascript['html-tagged-template-string']) {
+      const tInterp = Prism.languages.javascript['template-string'].inside.interpolation;
+      // insert interpolation ${} highlighting in html before tags
+      Prism.languages.insertBefore('html', 'tag', {
+        interpolation: {
+          pattern: tInterp.pattern,
+          inside: tInterp.inside
+        }
+      });
+
+      // insert interpolation ${} highlihgting inside html tags' before attr values
+      Prism.languages.insertBefore('inside', 'attr-value', {
+        interpolation: {
+          pattern: tInterp.pattern,
+          inside: tInterp.inside
+        }
+      }, Prism.languages.html.tag);
+
+      const htmlTokens = Prism.languages.html;
+      // insert tagged-template highlighting
+      Prism.languages.insertBefore('javascript','template-string', {
+        'html-tagged-template-string': {
+          // this is just the pattern "html" prepended to the default pattern
+          // for template literals found in
+          // Prism.languages.javascript['template-string'].pattern
+          pattern: /html`(?:\\[\s\S]|\${[^}]+}|[^\\`])*`/,
+          alias: 'language-html',
+          inside: htmlTokens
+        }
+      });
+    }
     Prism.highlightAllUnder(this.shadowRoot);
   }
 
@@ -41,7 +73,7 @@ export class ReadmeContainer extends LitElement{
   }
 
   /**
-   * After each render, call a function to highlight code blocks. 
+   * After each render, call a function to highlight code blocks.
    */
   _didRender(){
     this.highlightCodeBlocks();

--- a/src/readme-container.js
+++ b/src/readme-container.js
@@ -27,21 +27,19 @@ export class ReadmeContainer extends LitElement{
     // add tagged template literal highlighting if not already defined
     if (!Prism.languages.javascript['html-tagged-template-string']) {
       const tInterp = Prism.languages.javascript['template-string'].inside.interpolation;
-      // insert interpolation ${} highlighting in html before tags
-      Prism.languages.insertBefore('html', 'tag', {
+      const interpToken = {
         interpolation: {
           pattern: tInterp.pattern,
           inside: tInterp.inside
         }
-      });
+      };
+
+      // insert interpolation ${} highlighting in html before tags in all HTML
+      Prism.languages.insertBefore('html', 'tag', interpToken);
 
       // insert interpolation ${} highlihgting inside html tags' before attr values
-      Prism.languages.insertBefore('inside', 'attr-value', {
-        interpolation: {
-          pattern: tInterp.pattern,
-          inside: tInterp.inside
-        }
-      }, Prism.languages.html.tag);
+      Prism.languages.insertBefore(
+          'inside', 'attr-value', interpToken, Prism.languages.html.tag);
 
       const htmlTokens = Prism.languages.html;
       // insert tagged-template highlighting


### PR DESCRIPTION
this adds tagged template highlighting only for HTML.

My implementation also adds highlighting for template-string interpolations `${javascriptStuff}` in all HTML, but I doubt that'll be an issue.

e.g. it will highlight `${...}` in

```html
<div>${something}</div>
```

so that it can lazily work in:

```js
html`
  <div>${something}</div>
`
```

The correct way to do this would probably be to use https://github.com/github/markup which is unfortunately a ruby library